### PR TITLE
Switch to /bin/bash in shell scripts as /bin/sh may not always be...

### DIFF
--- a/assembly/src/main/filtered-resources/unix/bin/jclouds
+++ b/assembly/src/main/filtered-resources/unix/bin/jclouds
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with

--- a/assembly/src/main/filtered-resources/unix/bin/shell
+++ b/assembly/src/main/filtered-resources/unix/bin/shell
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
...a symlink to /bin/bash. May show up again in jclouds-cli since we just copy that from karaf.
