### PR TITLE
Return specific error codes where possible

### DIFF
--- a/assembly/src/main/filtered-resources/unix/bin/shell
+++ b/assembly/src/main/filtered-resources/unix/bin/shell
@@ -262,6 +262,8 @@ setupDefaults() {
 
     # Setup classpath
     CLASSPATH="$KARAF_HOME/system/org/jclouds/cli/runner/${project.version}/runner-${project.version}.jar"
+    CLASSPATH="$CLASSPATH:$KARAF_HOME/system/org/jclouds/jclouds-core/${project.version}/jclouds-core-${project.version}.jar"
+    CLASSPATH="$CLASSPATH:$KARAF_HOME/system/org/jclouds/jclouds-blobstore/${project.version}/jclouds-blobstore-${project.version}.jar"
     CLASSPATH="$CLASSPATH:$KARAF_HOME/system/org/apache/karaf/shell/org.apache.karaf.shell.console/${karaf.version}/org.apache.karaf.shell.console-${karaf.version}.jar"
     #We set external libraries for logging.
     CLASSPATH="$CLASSPATH:$KARAF_HOME/lib/other/slf4j-api-${slf4j.version}.jar:$KARAF_HOME/lib/other/slf4j-log4j12-${slf4j.version}.jar:$KARAF_HOME/lib/other/log4j-${log4j.version}.jar"

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -34,6 +34,18 @@
             <artifactId>org.apache.karaf.shell.console</artifactId>
             <version>${karaf.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-blobstore</artifactId>
+            <version>${jclouds.karaf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${jclouds.karaf.version}</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
We use Unix errno values where it makes sense.  Print the stack trace
and return 255 when we have an internal error.  We will need to return
more specific errors from jclouds and jclouds-karaf for this commit to
work well.  References #36.
