### PR TITLE
Allow specifying extra options to the Java cmdline.

### DIFF
--- a/assembly/src/main/filtered-resources/unix/bin/shell
+++ b/assembly/src/main/filtered-resources/unix/bin/shell
@@ -317,7 +317,7 @@ run() {
         CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
     fi
 
-    exec $JAVA $JAVA_OPTS -Dkaraf.instances="${KARAF_HOME}/instances" -Dkaraf.home="$KARAF_HOME" -Dkaraf.base="$KARAF_BASE" -Djava.io.tmpdir="$KARAF_DATA/tmp" -Dlog4j.configuration=file://$KARAF_BASE/etc/log4j.properties $KARAF_OPTS $OPTS -classpath "$CLASSPATH" org.jclouds.cli.runner.Main "$@"
+    exec $JAVA $JAVA_OPTS ${EXTRA_JAVA_OPTS:-} -Dkaraf.instances="${KARAF_HOME}/instances" -Dkaraf.home="$KARAF_HOME" -Dkaraf.base="$KARAF_BASE" -Djava.io.tmpdir="$KARAF_DATA/tmp" -Dlog4j.configuration=file://$KARAF_BASE/etc/log4j.properties $KARAF_OPTS $OPTS -classpath "$CLASSPATH" org.jclouds.cli.runner.Main "$@"
 }
 
 main() {


### PR DESCRIPTION
Among other things, this enables callers to configure HTTP proxy
via environment variables.
