### PR TITLE
Explicitly call exit on success

### DIFF
--- a/runner/src/main/java/org/jclouds/cli/runner/Main.java
+++ b/runner/src/main/java/org/jclouds/cli/runner/Main.java
@@ -111,6 +111,9 @@ public class Main {
             t.printStackTrace();
             System.exit(Errno.UNKNOWN.getErrno());
         }
+        // We must explicitly exit on success since we do not close
+        // BlobStoreContext and ComputeServiceContext.
+        System.exit(0);
     }
 
     /**


### PR DESCRIPTION
jclouds-karaf does not close BlobStoreContext or ComputeServiceContext
which caused some jclouds-cli commands to hang.  Work around this by
explicitly exiting.
